### PR TITLE
improved numeric types in `board`

### DIFF
--- a/src/board.rs
+++ b/src/board.rs
@@ -22,22 +22,22 @@ fn bounds(mut query: Query<&mut Location, With<snake::Head>>) {
     }
 }
 
-pub type XCoord = i8;
-pub type YCoord = i8;
+pub type Coord = i8;
+pub type XCoord = Coord;
+pub type YCoord = Coord;
 
-pub const WIDTH: XCoord = 16;
-pub const HEIGHT: YCoord = 9;
+pub type Size = u8;
+pub type XSize = Size;
+pub type YSize = Size;
+
+pub const WIDTH: XSize = 16;
+pub const HEIGHT: YSize = 9;
 
 fn is_in_bounds(x: XCoord, y: YCoord) -> bool {
-    get_bound_range(WIDTH as i8).contains(&x) && get_bound_range(HEIGHT as i8).contains(&y)
+    get_bound_range(WIDTH).contains(&x) && get_bound_range(HEIGHT).contains(&y)
 }
 
-fn get_bound_range(size: i8) -> RangeInclusive<i8> {
-    let half = size as i8 / 2;
-
-    if size % 2 == 1 {
-        -half..=half
-    } else {
-        -(half - 1)..=half
-    }
+fn get_bound_range(size: Size) -> RangeInclusive<i8> {
+    let half = (size / 2) as i8;
+    if size % 2 == 1 { -half..=half } else { -(half - 1)..=half }
 }

--- a/src/render.rs
+++ b/src/render.rs
@@ -1,7 +1,7 @@
 use bevy::prelude::*;
 use crate::location::Location;
 use crate::board;
-use crate::board::{XCoord, YCoord};
+use crate::board::{Coord, XCoord, YCoord, Size, XSize, YSize};
 use crate::snake;
 
 pub struct Plugin;
@@ -55,13 +55,7 @@ fn get_tile_pixel_position(x: XCoord, y: YCoord, height: f32) -> Vec3 {
     )
 }
 
-fn calculate_pixel_coordinate(coord: i8, size: i8) -> f32 {
-    let coord = coord as f32 * TILE_SIZE;
-    if size % 2 == 1 {
-        coord
-    } else {
-        coord - (TILE_SIZE / 2.0)
-    }
+fn calculate_pixel_coordinate(coord: Coord, size: Size) -> f32 {
+    let pixel_coord = coord as f32 * TILE_SIZE;
+    if size % 2 == 1 { pixel_coord } else { pixel_coord - (TILE_SIZE / 2.0) }
 }
-
-


### PR DESCRIPTION
Currently we only have signed `XCoord` and `YCoord`, which is a problem because in some places (like the size of the board) we should have an unsigned value. also, for some functions it doesn't matter whether its an X or a Y value.